### PR TITLE
Interactive authentication prompts the default choice only if it's an…

### DIFF
--- a/pkg/auth/identity/ark_identity.go
+++ b/pkg/auth/identity/ark_identity.go
@@ -422,10 +422,6 @@ func (ai *ArkIdentity) pickMechanism(challenge *identity.Challenge) (*identity.M
 			}
 		}
 	}
-	var defaultChoice string
-	if ai.mfaType != "" {
-		defaultChoice = factors[strings.ToLower(ai.mfaType)]
-	}
 	options := make([]string, len(supportedMechanisms))
 	for i, m := range supportedMechanisms {
 		options[i] = factors[strings.ToLower(m.Name)]
@@ -434,7 +430,16 @@ func (ai *ArkIdentity) pickMechanism(challenge *identity.Challenge) (*identity.M
 	prompt := &survey.Select{
 		Message: "Please pick one of the following MFA methods",
 		Options: options,
-		Default: defaultChoice,
+	}
+
+	if ai.mfaType != "" {
+		mfaTypeFactor := factors[strings.ToLower(ai.mfaType)]
+		for _, option := range options {
+			if option == mfaTypeFactor {
+				prompt.Default = option
+				break
+			}
+		}
 	}
 
 	var selectedOption string


### PR DESCRIPTION
### Desired Outcome

In the ark cli, authentication fails with following error after choosing the password:
```
Failed to authenticate with Identity Security Platform: default value "🔑 User Password" not found in options
```

The error is triggered when the authentication requires a second factor (e.g. push, sms) and the `defaultChoice` isn't in the remaining `options`:

https://github.com/Kalybus/ark-sdk-golang/blob/27318bf53ce87d1e70bc213b20ce7f4ce3e76bfd/pkg/auth/identity/ark_identity.go#L436-L437

### Implemented Changes

The `defaultChoice` is set only if the option is available.

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
